### PR TITLE
Fix migrations running.

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -20,7 +20,7 @@ logger = logging.getLogger('alembic.env')
 from flask import current_app
 config.set_main_option('sqlalchemy.url',
                        current_app.config.get('SQLALCHEMY_DATABASE_URI'))
-target_metadata = current_app.extensions['migrate'].db.metadata
+target_metadata = current_app.extensions['sqlalchemy'].db.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:


### PR DESCRIPTION
Apparently the DB object doesn't exist on the migrate
extension anymore, so we retrieve it from the sqlalchemy
extension instead.
